### PR TITLE
Remove display of territory after resignations

### DIFF
--- a/www/static/js/go.js
+++ b/www/static/js/go.js
@@ -2074,7 +2074,12 @@ var GameController = Class.create({
         if (this.game_is_finished) {
             // In case an old window hasn't updated until now.
             this.update_scoring(scoring_number, white_territory, black_territory);
-            $("territory_message").removeClassName("hide");
+
+            if (!this.by_resignation())
+            {
+                $("territory_message").removeClassName("hide");
+            }
+
             this.finish_game();
         } else if (this.game_is_scoring) {
             this.start_scoring(white_territory, black_territory, scoring_number);

--- a/www/templates/play.html
+++ b/www/templates/play.html
@@ -71,11 +71,11 @@
             {% if you_are_black %}
             <div id="capture_message" {% if not any_captures %}class="hide"{% endif %}>You have captured <span class="count" id="white_stones_captured">{{white_stones_captured}}</span> stones; {{white_name}} has captured <span class="count" id="black_stones_captured">{{black_stones_captured}}</span>.</div>
             <div id="komi_message">{{white_name}} has <span class="count" id="komi">{{komi}}</span> komi.</div>
-            <div id="territory_message" {% if game_in_progress_python %}class="hide"{% endif %}>You have <span class="count" id="black_territory">{{black_territory}}</span> territory; {{white_name}} has <span class="count" id="white_territory">{{white_territory}}</span> territory.</div>
+            <div id="territory_message" {% if not has_scoring_data %}class="hide"{% endif %}>You have <span class="count" id="black_territory">{{black_territory}}</span> territory; {{white_name}} has <span class="count" id="white_territory">{{white_territory}}</span> territory.</div>
             {% else %}
             <div id="capture_message" {% if not any_captures %}class="hide"{% endif %} >You have captured <span class="count" id="black_stones_captured">{{black_stones_captured}}</span> stones; {{black_name}} has captured <span class="count" id="white_stones_captured">{{white_stones_captured}}</span>.</div>
             <div id="komi_message">You have <span class="count" id="komi">{{komi}}</span> komi.</div>
-            <div id="territory_message" {% if game_in_progress_python %}class="hide"{% endif %}>You have <span class="count" id="white_territory">{{white_territory}}</span> territory; {{black_name}} has <span class="count" id="black_territory">{{black_territory}}</span> territory.</div>
+            <div id="territory_message" {% if not has_scoring_data %}class="hide"{% endif %}>You have <span class="count" id="white_territory">{{white_territory}}</span> territory; {{black_name}} has <span class="count" id="black_territory">{{black_territory}}</span> territory.</div>
             {% endif %}
             
             {% if game_is_finished_python %}


### PR DESCRIPTION
Territory numbers are invalid (-1) if someone resigns, so they should not be displayed.
